### PR TITLE
Kaenova/attachments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,55 +1,42 @@
-.PHONY: help dev dev-backend dev-frontend dev-graph dev-graph-backend build-frontend clean install-backend install-frontend setup langgraph-test langgraph-setup langgraph-install
+.PHONY: help dev dev-backend dev-frontend build-frontend clean install setup langgraph-setup langgraph-install
 
 # Default target
 help:
 	@echo "Available commands:"
 	@echo "  make dev              - Start both backend and frontend in development mode"
-	@echo "  make dev-backend      - Start only the mock backend server"
+	@echo "  make dev-backend      - Start only the backend server"
 	@echo "  make dev-frontend     - Start only the frontend development server"
-	@echo "  make dev-graph        - Start frontend and LangGraph FastAPI server"
 	@echo "  make build-frontend   - Build the frontend for production"
 	@echo "  make clean            - Clean up generated files"
 	@echo "  make install          - Install dependencies for both projects"
 	@echo "  make setup            - Initial setup for both projects"
 	@echo ""
-	@echo "LangGraph commands:"
-	@echo "  make langgraph-setup  - Setup LangGraph server environment"
-	@echo "  make langgraph-install - Install LangGraph dependencies"
-	@echo "  make langgraph-test   - Test LangGraph server setup"
+	@echo "Backend commands:"
+	@echo "  make langgraph-setup  - Setup backend server environment"
+	@echo "  make langgraph-install - Install backend dependencies"
 
 # Development - Start both services
-dev-old:
-	@echo "🚀 Starting both mock backend and frontend..."
-	@echo "📡 Backend will be available at: http://localhost:8000"
-	@echo "🌐 Frontend will be available at: http://localhost:3000"
-	@echo ""
-	@echo "Press Ctrl+C to stop both services"
-	@make -j2 dev-backend dev-frontend
 
-# Start mock backend server
+# Start backend server
 dev-backend:
-	@echo "🔧 Starting mock backend server..."
-	cd mock-server && bun run server.ts
+	@echo "🔧 Starting backend server..."
+	@echo "This is not reloadable. Restart this command to apply changes."
+	cd mock-backend && uv run uvicorn main:app --host 0.0.0.0 --port 8000
 
 # Start frontend development server
 dev-frontend:
 	@echo "⚛️  Starting frontend development server..."
 	@sleep 2 && bun run dev
 
-# Start frontend and LangGraph FastAPI server
+# Start frontend and backend server
 dev:
-	@echo "🚀 Starting frontend and LangGraph FastAPI server..."
-	@echo "🤖 LangGraph API will be available at: http://localhost:8000"
+	@echo "🚀 Starting frontend and backend server..."
+	@echo "🔧 Backend will be available at: http://localhost:8000"
 	@echo "🌐 Frontend will be available at: http://localhost:3000"
 	@echo ""
 	@echo "Press Ctrl+C to stop both services"
-	@make -j2 dev-graph-backend dev-frontend
+	@make -j2 dev-backend dev-frontend
 
-# Start LangGraph FastAPI server
-dev-graph-backend:
-	@echo "🤖 Starting LangGraph FastAPI server..."
-	@echo "This is not reloadable. Restart this command to apply changes."
-	cd mock-backend && uv run uvicorn main:app --host 0.0.0.0 --port 8000
 
 # Build frontend for production
 build-frontend:
@@ -61,21 +48,19 @@ clean:
 	@echo "🧹 Cleaning up generated files..."
 	rm -rf .next
 	rm -rf node_modules
-	rm -rf mock-server/node_modules
-	rm -rf mock-server/chatbot-db.json
+	rm -rf mock-backend/.venv
 	rm -f bun.lock
-	rm -f mock-server/bun.lock
 
 # Install dependencies for both projects
 install:
 	@echo "📥 Installing dependencies..."
 	@echo "Installing frontend dependencies..."
 	bun install
-	@echo "Installing mock server dependencies..."
-	cd mock-server && bun install
+	@echo "Installing backend dependencies..."
+	cd mock-backend && uv sync
 
 # Initial setup
-setup: install
+setup: install langgraph-setup
 	@echo "⚙️  Setting up environment..."
 	@if [ ! -f .env.local ]; then \
 		echo "Creating .env.local from .env.example..."; \
@@ -85,13 +70,13 @@ setup: install
 	@echo ""
 	@echo "Next steps:"
 	@echo "1. Configure your environment variables in .env.local"
-	@echo "2. Run 'make dev' to start both services"
-	@echo "3. Open http://localhost:3000 in your browser"
+	@echo "2. Edit mock-backend/.env with your credentials if needed"
+	@echo "3. Run 'make dev' to start both services"
+	@echo "4. Open http://localhost:3000 in your browser"
 
 # Stop all running services
 stop:
 	@echo "🛑 Stopping all services..."
-	-pkill -f "bun run server.ts" || true
 	-pkill -f "next dev" || true
 	-pkill -f "bun run dev" || true
 	-pkill -f "uvicorn main:app" || true
@@ -100,8 +85,7 @@ stop:
 # Show status of running services
 status:
 	@echo "📊 Service Status:"
-	@pgrep -f "bun run server.ts" > /dev/null && echo "✅ Mock Backend: Running (PID: $$(pgrep -f "bun run server.ts"))" || echo "❌ Mock Backend: Not running"
-	@pgrep -f "uvicorn main:app" > /dev/null && echo "✅ LangGraph API: Running (PID: $$(pgrep -f "uvicorn main:app"))" || echo "❌ LangGraph API: Not running"
+	@pgrep -f "uvicorn main:app" > /dev/null && echo "✅ Backend: Running (PID: $$(pgrep -f "uvicorn main:app"))" || echo "❌ Backend: Not running"
 	@pgrep -f "next dev\|bun run dev" > /dev/null && echo "✅ Frontend: Running (PID: $$(pgrep -f "next dev\|bun run dev"))" || echo "❌ Frontend: Not running"
 
 # Development with logs
@@ -112,37 +96,22 @@ dev-logs:
 	@make -j2 dev-backend-logs dev-frontend-logs
 
 dev-backend-logs:
-	cd mock-server && bun run server.ts 2>&1 | tee ../backend.log
+	cd mock-backend && uv run uvicorn main:app --host 0.0.0.0 --port 8000 2>&1 | tee ../backend.log
 
 dev-frontend-logs:
 	bun run dev 2>&1 | tee frontend.log
 
-# Database operations
-db-reset:
-	@echo "🔄 Resetting database..."
-	rm -f mock-server/chatbot-db.json
-	@echo "✅ Database reset"
-
-db-backup:
-	@echo "💾 Backing up database..."
-	cp mock-server/chatbot-db.json mock-server/chatbot-db.backup.json 2>/dev/null || echo "No database file to backup"
-	@echo "✅ Database backed up"
-
-db-restore:
-	@echo "🔄 Restoring database..."
-	cp mock-server/chatbot-db.backup.json mock-server/chatbot-db.json 2>/dev/null || echo "No backup file found"
-	@echo "✅ Database restored"
 
 langgraph-setup:
-	@echo "⚙️  Setting up LangGraph server..."
+	@echo "⚙️  Setting up backend server..."
 	@if [ ! -f mock-backend/.env ]; then \
 		echo "Creating .env from env.sample..."; \
 		cp mock-backend/env.sample mock-backend/.env; \
 		echo "⚠️  Please edit mock-backend/.env with your Azure OpenAI credentials"; \
 	fi
-	@echo "✅ LangGraph setup complete!"
+	@echo "✅ Backend setup complete!"
 
 langgraph-install:
-	@echo "📥 Installing LangGraph dependencies..."
+	@echo "📥 Installing backend dependencies..."
 	cd mock-backend && uv sync
-	@echo "✅ LangGraph dependencies installed"
+	@echo "✅ Backend dependencies installed"

--- a/mock-backend/.gitignore
+++ b/mock-backend/.gitignore
@@ -60,3 +60,5 @@ Thumbs.db
 
 # UV
 .uv/
+
+tmp

--- a/mock-backend/agent/graph.py
+++ b/mock-backend/agent/graph.py
@@ -8,6 +8,11 @@ from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from langgraph.prebuilt import ToolNode
 import aiosqlite
 
+from langchain_core.messages.utils import (
+    trim_messages,
+    count_tokens_approximately
+)
+
 from .tools import AVAILABLE_TOOLS
 from .model import model
 
@@ -46,6 +51,16 @@ def call_model(state: AgentState, config = None) -> Dict[str, List[BaseMessage]]
         Dict containing the updated messages
     """
     messages = state["messages"]
+
+    # Trim messages to fit within token limit
+    messages = trim_messages(
+        state["messages"],
+        strategy="last",
+        token_counter=count_tokens_approximately,
+        max_tokens=120_000,
+        start_on="human",
+        end_on=("human", "tool"),
+    )
 
     system_prompt = """
 # Your Role

--- a/mock-backend/agent/tools.py
+++ b/mock-backend/agent/tools.py
@@ -137,8 +137,8 @@ if (os.getenv("AZURE_SEARCH_ENDPOINT") and
                 chunk_index = result['metadata'].get('chunk_index', 0)
                 id_ = result['metadata'].get('id', 'Unknown')
                 content = result['content']
-                output += f"# {filename} {chunk_index}\n"
-                output += f"- chunk_id/id: {id_}\n"
+                output += f"# File: {filename} Chunk [{chunk_index}]\n"
+                output += f"**chunk_id/id**: `{id_}`\n"
                 output += "Content:\n```\n"
                 output += f"{content}\n"
                 output += "```\n\n"
@@ -202,8 +202,8 @@ if (os.getenv("AZURE_SEARCH_ENDPOINT") and
                 chunk_index = result['metadata'].get('chunk_index', 0)
                 id_ = result['metadata'].get('id', 'Unknown')
                 content = result['content']
-                output += f"# {filename} {chunk_index}\n"
-                output += f"- chunk_id/id: {id_}\n"
+                output += f"# File: {filename} Chunk [{chunk_index}]\n"
+                output += f"**chunk_id/id**: `{id_}`\n"
                 output += "Content:\n```\n"
                 output += f"{content}\n"
                 output += "```\n\n"
@@ -256,8 +256,8 @@ if (os.getenv("AZURE_SEARCH_ENDPOINT") and
                 chunk_index = result['metadata'].get('chunk_index', 0)
                 id_ = result['metadata'].get('id', 'Unknown')
                 content = result['content']
-                output += f"# {filename} {chunk_index}\n"
-                output += f"- chunk_id/id: {id_}\n"
+                output += f"# File: {filename} Chunk [{chunk_index}]\n"
+                output += f"**chunk_id/id**: `{id_}`\n"
                 output += "Content:\n```\n"
                 output += f"{content}\n"
                 output += "```\n\n"
@@ -335,8 +335,8 @@ if (os.getenv("AZURE_SEARCH_ENDPOINT") and
                         chunk_index = result['metadata'].get('chunk_index', 0)
                         id_ = result['metadata'].get('id', 'Unknown')
                         content = result['content']
-                        output += f"# {filename} {chunk_index}\n"
-                        output += f"- chunk_id/id: {id_}\n"
+                        output += f"# File: {filename} Chunk [{chunk_index}]\n"
+                        output += f"**chunk_id/id**: {id_}\n"
                         output += "Content:\n```\n"
                         output += f"{content}\n"
                         output += "```\n\n"

--- a/mock-backend/utils/message_conversion.py
+++ b/mock-backend/utils/message_conversion.py
@@ -1,0 +1,94 @@
+
+import urllib
+
+"""
+private async fileToBase64DataURL(file: File): Promise<string> {
+    // Extract to base64 with filename added
+    // Example
+    "data:text/csv;base64,TmFtZSxBZ2UsQnJlZWQsQ29sb3IKQnVkZHksMyxHb2xkZW4gUmV0cmlldmVyLEdvbGRlbgpNYXgsNSxHZXJtYW4gU2hlcGhlcmQsQmxhY2sgYW5kIFRhbgpCYWlsZXksMixMYWJyYWRvciBSZXRyaWV2ZXIsQ2hvY29sYXRlCkx1Y3ksNCxCZWFnbGUsVHJpLWNvbG9yCkNoYXJsaWUsNixQb29kbGUsV2hpdGUKRGFpc3ksMSxCdWxsZG9nLEJyb3duIGFuZCBXaGl0ZQpDb29wZXIsNyxTaWJlcmlhbiBIdXNreSxHcmF5IGFuZCBXaGl0ZQpNb2xseSw0LERhY2hzaHVuZCxSZWQKUm9ja3ksMixCb3hlcixGYXduCkJlbGxhLDUsWW9ya3NoaXJlIFRlcnJpZXIsQmxhY2sgYW5kIFRhbg==,filename:dogs%20data.csv"
+
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+
+      reader.onload = () => {
+        resolve(`${reader.result},filename:${encodeURIComponent(file.name)}`);
+      };
+
+      reader.onerror = (error) => {
+        reject(error);
+      };
+
+      reader.readAsDataURL(file); // Read the file as a Data URL
+    });
+  }
+import urllib.parse
+ 
+ 
+"""
+
+def decode_file_attachment(data_url: str) -> dict:
+    """Decode base64 data URL to dictionary with mimetype, base64data, filename."""
+    if not data_url.startswith("data:"):
+        raise ValueError("Invalid data URL format")
+
+    parts = data_url.split(",")
+    if len(parts) < 2:
+        raise ValueError("Invalid data URL format")
+
+    header = parts[0]
+    base64data = parts[1]
+
+    # Parse mimetype from header
+    if ":" not in header or ";" not in header.split(":", 1)[1]:
+        raise ValueError("Invalid header format")
+    mimetype = header.split(":", 1)[1].split(";", 1)[0]
+
+    filename = None
+    if len(parts) > 2:
+        filename_part = parts[2]
+        if filename_part.startswith("filename:"):
+            encoded_filename = filename_part[9:]
+            filename = urllib.parse.unquote(encoded_filename)
+
+    return {
+        "mimetype": mimetype,
+        "base64data": base64data,
+        "filename": filename
+    }
+
+def from_assistant_ui_contents_to_langgraph_contents(message: list[any]) -> dict:
+    """Convert an Assistant UI message to a Langgraph message."""
+    langgraph_contents = []
+
+    for content in message:
+        if content.get("type") == "text":
+            langgraph_contents.append({
+                "type": "text",
+                "text": content.get("text", "")
+            })
+            continue
+
+        if content.get("type") == "file":
+            file_data = decode_file_attachment(content.get("data"))
+            langgrapH_content = {
+                "type": "file",
+                "source_type": "base64",
+                "filename": file_data["filename"],
+                "mime_type": file_data["mimetype"],
+                "data": file_data["base64data"]
+            }
+            langgraph_contents.append(langgrapH_content)
+            continue
+
+        if content.get("type") == "image":
+            file_data = decode_file_attachment(content.get("image"))
+            langgraph_content = {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:{file_data['mimetype']};base64,{file_data['base64data']}",
+                },
+            }
+            langgraph_contents.append(langgraph_content)
+            continue
+    
+    return langgraph_contents

--- a/src/app/chat/[conversationId]/page.tsx
+++ b/src/app/chat/[conversationId]/page.tsx
@@ -53,7 +53,7 @@ function ChatPage() {
     },
   }
 
-   const runtime = ChatWithConversationIDAPIRuntime(conversationId, HistoryAdapter)
+  const runtime = ChatWithConversationIDAPIRuntime(conversationId, HistoryAdapter)
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>

--- a/src/components/assistant-ui/custom-markdown/CustomDocReference.tsx
+++ b/src/components/assistant-ui/custom-markdown/CustomDocReference.tsx
@@ -1,25 +1,24 @@
 "use client";
 
-import { Download, ExternalLinkIcon, FileTextIcon } from "lucide-react";
+/**
+ * Component that handles markdown format
+ * [doc-(....)]
+ */
+
+import { Download, FileTextIcon } from "lucide-react";
 import { type FC, useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { ChunkData, getChunkData } from "@/lib/integration/client/chunk";
 
 // Props for the doc placeholder component
-interface DocPlaceholderProps {
+interface CustomDocReferenceProps {
   id: string;
   className?: string;
   onClick?: (id: string) => void;
 }
 
-// Props for the link placeholder component
-interface LinkPlaceholderProps {
-  url: string;
-  className?: string;
-}
-
-export const DocPlaceholder: FC<DocPlaceholderProps> = ({
+export const CustomDocReference: FC<CustomDocReferenceProps> = ({
   id,
   className,
   onClick
@@ -125,37 +124,3 @@ export const DocPlaceholder: FC<DocPlaceholderProps> = ({
   );
 };
 
-// Placeholder component for [link-(url)] patterns
-export const LinkPlaceholder: FC<LinkPlaceholderProps> = ({ 
-  url, 
-  className 
-}) => {
-  const handleClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    window.open(url, '_blank', 'noopener,noreferrer');
-  };
-
-  // Extract domain for display
-  const getDomain = (url: string) => {
-    try {
-      const domain = new URL(url).hostname;
-      return domain.replace('www.', '');
-    } catch {
-      return url.length > 30 ? url.substring(0, 30) + '...' : url;
-    }
-  };
-
-  return (
-    <button
-      onClick={handleClick}
-      className={cn(
-        "aui-link-placeholder inline-flex items-center gap-1 rounded-md bg-primary/5 px-2 py-1 text-sm font-medium text-primary/80 hover:bg-primary/10 hover:text-primary transition-colors border border-primary/15 hover:border-primary/25 mx-2",
-        className
-      )}
-      title={`Open link: ${url}`}
-    >
-      <ExternalLinkIcon className="h-3 w-3" />
-      <span>{getDomain(url)}</span>
-    </button>
-  );
-};

--- a/src/components/assistant-ui/custom-markdown/CustomLinkReference.tsx
+++ b/src/components/assistant-ui/custom-markdown/CustomLinkReference.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { ExternalLinkIcon } from "lucide-react";
+import { type FC } from "react";
+import { cn } from "@/lib/utils";
+
+
+/**
+ * Component that handles markdown format
+ * [link-(....)]
+ */
+
+// Props for the link placeholder component
+interface CustomLinkReferenceProps {
+  url: string;
+  className?: string;
+}
+
+// Placeholder component for [link-(url)] patterns
+export const CustomLinkReference: FC<CustomLinkReferenceProps> = ({ 
+  url, 
+  className 
+}) => {
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  // Extract domain for display
+  const getDomain = (url: string) => {
+    try {
+      const domain = new URL(url).hostname;
+      return domain.replace('www.', '');
+    } catch {
+      return url.length > 30 ? url.substring(0, 30) + '...' : url;
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className={cn(
+        "aui-link-placeholder inline-flex items-center gap-1 rounded-md bg-primary/5 px-2 py-1 text-sm font-medium text-primary/80 hover:bg-primary/10 hover:text-primary transition-colors border border-primary/15 hover:border-primary/25 mx-2",
+        className
+      )}
+      title={`Open link: ${url}`}
+    >
+      <ExternalLinkIcon className="h-3 w-3" />
+      <span>{getDomain(url)}</span>
+    </button>
+  );
+};

--- a/src/components/assistant-ui/custom-markdown/index.ts
+++ b/src/components/assistant-ui/custom-markdown/index.ts
@@ -1,3 +1,2 @@
-// Custom Markdown Placeholder Components
-// These are the components used by the integrated markdown system in markdown-text.tsx
-export { DocPlaceholder, LinkPlaceholder } from './placeholders';
+export { CustomDocReference } from "./CustomDocReference";
+export { CustomLinkReference } from "./CustomLinkReference";

--- a/src/components/assistant-ui/markdown-text.tsx
+++ b/src/components/assistant-ui/markdown-text.tsx
@@ -18,11 +18,11 @@ import { cn } from "@/lib/utils";
 import { SyntaxHighlighter } from "./shiki-highlighter";
 
 import { MermaidDiagram } from "@/components/assistant-ui/mermaid-diagram";
-import { DocPlaceholder, LinkPlaceholder } from "@/components/assistant-ui/custom-markdown/placeholders";
 
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import rehypeRaw from "rehype-raw";
+import { CustomDocReference, CustomLinkReference } from "./custom-markdown";
 
 
 function normalizeCustomMathTags(input: string): string {
@@ -271,18 +271,20 @@ const defaultComponents = memoizeMarkdownComponents({
   CodeHeader,
   // Custom span handler for placeholder components
   span: ({ className, children, ...props }: React.HTMLAttributes<HTMLSpanElement> & { children?: React.ReactNode }) => {
-    // Handle custom doc placeholders
+    // Handle custom doc 
+    // format: [doc-(...)]
     if (className === 'custom-doc-placeholder') {
       const dataProps = props as Record<string, string>;
       const id = dataProps['data-id'];
-      return <DocPlaceholder id={id} />;
+      return <CustomDocReference id={id} />;
     }
     
     // Handle custom link placeholders
+    // format: [link-(...)]
     if (className === 'custom-link-placeholder') {
       const dataProps = props as Record<string, string>;
       const url = dataProps['data-url'];
-      return <LinkPlaceholder url={url} />;
+      return <CustomLinkReference url={url} />;
     }
     
     // Default span behavior

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -231,11 +231,12 @@ interface ComposerProps {
 
 const Composer: FC<ComposerProps> = ({ isDisabled = false }) => {
 
+  const threadExist = useAssistantState(({thread}) => thread.messages.length > 0)
   const text = useAssistantState(({composer}) => composer.text)
   const isEmpty = text.trim().length < 1
 
   return (
-    <div className="aui-composer-wrapper sticky bottom-0 mx-auto flex w-full max-w-[var(--thread-max-width)] flex-col gap-4 overflow-visible rounded-t-3xl bg-background pb-4 md:pb-6">
+    <div className="aui-composer-wrapper sticky bottom-0 mx-auto flex w-full max-w-[var(--thread-max-width)] flex-col gap-4 overflow-visible rounded-t-3xl bg-background pb-2 md:pb-4">
       <ThreadScrollToBottom />
       {
         !isDisabled &&
@@ -243,21 +244,34 @@ const Composer: FC<ComposerProps> = ({ isDisabled = false }) => {
         <ThreadWelcomeSuggestions />
       </ThreadPrimitive.Empty>
       }
-      <ComposerPrimitive.Root className={cn(
-        "aui-composer-root relative flex w-full flex-col rounded-3xl border border-border bg-muted px-1 pt-2 shadow-[0_9px_9px_0px_rgba(0,0,0,0.01),0_2px_5px_0px_rgba(0,0,0,0.06)] dark:border-muted-foreground/15",
-        isDisabled && "opacity-50 pointer-events-none"
-      )}>
-        <ComposerAttachments />
-        <ComposerPrimitive.Input
-          placeholder={isDisabled ? "Loading conversation..." : "Send a message..."}
-          className="aui-composer-input mb-1 max-h-32 min-h-16 w-full resize-none bg-transparent px-3.5 pt-1.5 pb-3 text-base outline-none placeholder:text-muted-foreground focus:outline-primary"
-          rows={1}
-          autoFocus={!isDisabled}
-          aria-label="Message input"
-          disabled={isDisabled}
-        />
-        <ComposerAction isDisabled={isDisabled || isEmpty} />
-      </ComposerPrimitive.Root>
+      <div className="flex flex-col space-y-2">
+        <ComposerPrimitive.Root className={cn(
+          "aui-composer-root relative flex w-full flex-col rounded-3xl border border-border bg-muted px-1 pt-2 shadow-[0_9px_9px_0px_rgba(0,0,0,0.01),0_2px_5px_0px_rgba(0,0,0,0.06)] dark:border-muted-foreground/15",
+          isDisabled && "opacity-50 pointer-events-none"
+        )}>
+          <ComposerAttachments />
+          <ComposerPrimitive.Input
+            placeholder={isDisabled ? "Loading conversation..." : "Send a message..."}
+            className="aui-composer-input mb-1 max-h-32 min-h-16 w-full resize-none bg-transparent px-3.5 pt-1.5 pb-3 text-base outline-none placeholder:text-muted-foreground focus:outline-primary"
+            rows={1}
+            autoFocus={!isDisabled}
+            aria-label="Message input"
+            disabled={isDisabled}
+            />
+          <ComposerAction isDisabled={isDisabled || isEmpty} />
+        </ComposerPrimitive.Root>
+        {
+          threadExist &&
+          <m.div 
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 10 }}
+            className="w-full text-muted-foreground text-xs text-center"
+          >
+            AI may be wrong. Verify important info.
+          </m.div>
+        }
+      </div>
     </div>
   );
 };

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -35,6 +35,11 @@ import { getSiteConfig } from "@/lib/site-config";
 import { getTimeOfDay } from "@/utils/time-utils";
 import { ChatMessageSkeleton } from "@/components/ChatMessageSkeleton";
 
+const Settings = {
+  attachments: true,
+  editMessages: false, // Currently we dont support editing user messages
+}
+
 interface ThreadProps {
   isLoading?: boolean;
 }
@@ -255,8 +260,10 @@ interface ComposerActionProps {
 const ComposerAction: FC<ComposerActionProps> = ({ isDisabled = false }) => {
   return (
     <div className="aui-composer-action-wrapper relative mx-1 mt-2 mb-2 flex items-center justify-between">
-      {/* Disable it for now, because we dont support file uploads yet
-      <ComposerAddAttachment /> */}
+      {
+        Settings.attachments &&
+        <ComposerAddAttachment />
+      }
 
       <ThreadPrimitive.If running={false}>
         <ComposerPrimitive.Send asChild>
@@ -363,7 +370,10 @@ const UserMessage: FC = () => {
         className="aui-user-message-root mx-auto grid w-full max-w-[var(--thread-max-width)] animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] gap-y-2 px-2 py-4 duration-200 fade-in slide-in-from-bottom-1 first:mt-3 last:mb-5 [&:where(>*)]:col-start-2"
         data-role="user"
       >
+      {
+        Settings.attachments &&
         <UserMessageAttachments />
+      }
 
         <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
           <div className="aui-user-message-content rounded-3xl bg-primary/15 px-5 py-2.5 break-words text-foreground">
@@ -371,8 +381,10 @@ const UserMessage: FC = () => {
           </div>
           <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2">
 
-          {/* Disable for now, because we dont support editing user messages yet
-            <UserActionBar /> */}
+          {
+            Settings.editMessages &&
+            <UserActionBar /> 
+          }
           </div>
         </div>
 

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -5,6 +5,7 @@ import {
   ErrorPrimitive,
   MessagePrimitive,
   ThreadPrimitive,
+  useAssistantState,
 } from "@assistant-ui/react";
 import {
   ArrowDownIcon,
@@ -46,6 +47,9 @@ interface ThreadProps {
 }
 
 export const Thread: FC<ThreadProps> = ({ isLoading = false }) => {
+
+
+
   return (
     <LazyMotion features={domAnimation}>
       <MotionConfig reducedMotion="user">
@@ -226,6 +230,10 @@ interface ComposerProps {
 }
 
 const Composer: FC<ComposerProps> = ({ isDisabled = false }) => {
+
+  const text = useAssistantState(({composer}) => composer.text)
+  const isEmpty = text.trim().length < 1
+
   return (
     <div className="aui-composer-wrapper sticky bottom-0 mx-auto flex w-full max-w-[var(--thread-max-width)] flex-col gap-4 overflow-visible rounded-t-3xl bg-background pb-4 md:pb-6">
       <ThreadScrollToBottom />
@@ -248,7 +256,7 @@ const Composer: FC<ComposerProps> = ({ isDisabled = false }) => {
           aria-label="Message input"
           disabled={isDisabled}
         />
-        <ComposerAction isDisabled={isDisabled} />
+        <ComposerAction isDisabled={isDisabled || isEmpty} />
       </ComposerPrimitive.Root>
     </div>
   );

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -38,6 +38,7 @@ import { ChatMessageSkeleton } from "@/components/ChatMessageSkeleton";
 const Settings = {
   attachments: true,
   editMessages: false, // Currently we dont support editing user messages
+  regenerate: false, // Currently we dont support regenerating assistant messages
 }
 
 interface ThreadProps {
@@ -354,10 +355,12 @@ const AssistantActionBar: FC = () => {
         </TooltipIconButton>
       </ActionBarPrimitive.Copy>
       <ActionBarPrimitive.Reload asChild>
-        {/* Disble for now, because we dont support regenerating messages yet
-        <TooltipIconButton tooltip="Refresh">
-          <RefreshCwIcon />
-        </TooltipIconButton> */}
+        {
+          Settings.regenerate &&
+          <TooltipIconButton tooltip="Refresh">
+            <RefreshCwIcon />
+          </TooltipIconButton>
+        }
       </ActionBarPrimitive.Reload>
     </ActionBarPrimitive.Root>
   );

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -223,7 +223,6 @@ export function ChatProvider({ children }: ChatProviderProps) {
         loadConversations()
       }, 20 * 1000); // Refresh every 20 seconds
       
-      
       return () => {
         clearInterval(autoUpdate)
       }

--- a/src/lib/integration/client/chat-conversation.ts
+++ b/src/lib/integration/client/chat-conversation.ts
@@ -1,15 +1,25 @@
 'use client'
 
-import { ThreadHistoryAdapter, ThreadMessage } from "@assistant-ui/react";
+import { CompositeAttachmentAdapter, SimpleImageAttachmentAdapter, SimpleTextAttachmentAdapter, ThreadHistoryAdapter, ThreadMessage } from "@assistant-ui/react";
 import { useDataStreamRuntime } from "@assistant-ui/react-data-stream";
 import { formatRelativeTime } from "@/utils/date-utils";
 import { loadFromLanggraphStateHistoryJSON } from "@/utils/langgraph-message-conversion";
 
 const BaseAPIPath = "/api/be"
 
+
+// Attachments Handler
+const CompositeAttachmentsAdapter = new CompositeAttachmentAdapter([
+  new SimpleImageAttachmentAdapter(),
+  new SimpleTextAttachmentAdapter(),
+])
+
 // First Chat API Runtime (without conversation ID parameters)
 export const FirstChatAPIRuntime = () => useDataStreamRuntime({
   api: `${BaseAPIPath}/chat`,
+  adapters: {
+    attachments: CompositeAttachmentsAdapter,
+  }
 })
 
 // Get Last Conversation ID from A User
@@ -39,7 +49,8 @@ export async function GetLastConversationId(): Promise<string | null> {
 export const ChatWithConversationIDAPIRuntime = (conversationId: string, historyAdapter: ThreadHistoryAdapter) => useDataStreamRuntime({
   api: `${BaseAPIPath}/conversations/${conversationId}/chat`,
   adapters: {
-    history: historyAdapter
+    history: historyAdapter,
+    attachments: CompositeAttachmentsAdapter,
   }
 })
 

--- a/src/utils/custom-data-stream-runtime.ts
+++ b/src/utils/custom-data-stream-runtime.ts
@@ -1,0 +1,176 @@
+"use client";
+
+/**
+ * This is a custom runtime for Assistant UI that connects to a data-streaming backend API.
+ * The custom is we only send a single message to the backend
+ */
+
+import {
+  AssistantRuntime,
+  ChatModelAdapter,
+  ChatModelRunOptions,
+  INTERNAL,
+  LocalRuntimeOptions,
+  ThreadMessage,
+  Tool,
+  useLocalRuntime,
+} from "@assistant-ui/react";
+import { z } from "zod";
+import { JSONSchema7 } from "json-schema";
+import {
+  AssistantMessageAccumulator,
+  DataStreamDecoder,
+  unstable_toolResultStream,
+} from "assistant-stream";
+import { asAsyncIterableStream } from "assistant-stream/utils";
+import { toLanguageModelMessages } from "@assistant-ui/react-data-stream";
+
+const { splitLocalRuntimeOptions } = INTERNAL;
+
+type HeadersValue = Record<string, string> | Headers;
+
+export type UseDataStreamRuntimeOptions = {
+  api: string;
+  onResponse?: (response: Response) => void | Promise<void>;
+  onFinish?: (message: ThreadMessage) => void;
+  onError?: (error: Error) => void;
+  onCancel?: () => void;
+  credentials?: RequestCredentials;
+  headers?: HeadersValue | (() => Promise<HeadersValue>);
+  body?: object;
+  sendExtraMessageFields?: boolean;
+} & LocalRuntimeOptions;
+
+type DataStreamRuntimeRequestOptions = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  messages: any[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tools: any;
+  system?: string | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  runConfig?: any;
+  unstable_assistantMessageId?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  state?: any;
+};
+
+const toAISDKTools = (tools: Record<string, Tool>) => {
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, tool]) => [
+      name,
+      {
+        ...(tool.description ? { description: tool.description } : undefined),
+        parameters: (tool.parameters instanceof z.ZodType
+          ? z.toJSONSchema(tool.parameters)
+          : tool.parameters) as JSONSchema7,
+      },
+    ]),
+  );
+};
+
+const getEnabledTools = (tools: Record<string, Tool>) => {
+  return Object.fromEntries(
+    Object.entries(tools).filter(
+      ([, tool]) => !tool.disabled && tool.type !== "backend",
+    ),
+  );
+};
+
+class CustomDataStreamRuntimeAdapter implements ChatModelAdapter {
+  constructor(
+    private options: Omit<
+      UseDataStreamRuntimeOptions,
+      keyof LocalRuntimeOptions
+    >,
+  ) {}
+
+  async *run({
+    messages,
+    runConfig,
+    abortSignal,
+    context,
+    unstable_assistantMessageId,
+    unstable_getMessage,
+  }: ChatModelRunOptions) {
+    const headersValue =
+      typeof this.options.headers === "function"
+        ? await this.options.headers()
+        : this.options.headers;
+
+    abortSignal.addEventListener(
+      "abort",
+      () => {
+        if (!abortSignal.reason?.detach) this.options.onCancel?.();
+      },
+      { once: true },
+    );
+
+    const headers = new Headers(headersValue);
+    headers.set("Content-Type", "application/json");
+
+    // Get the last messages
+    if (messages.length === 0) {
+      throw new Error("No messages to send");
+    }
+    
+    // Send only the last message to the backend
+    const lastMessages = [messages[messages.length - 1]];
+
+    const result = await fetch(this.options.api, {
+      method: "POST",
+      headers,
+      credentials: this.options.credentials ?? "same-origin",
+      body: JSON.stringify({
+        system: context.system,
+        messages: toLanguageModelMessages(lastMessages, {
+          unstable_includeId: this.options.sendExtraMessageFields,
+        }) as DataStreamRuntimeRequestOptions["messages"],
+        tools: toAISDKTools(
+          getEnabledTools(context.tools ?? {}),
+        ) as unknown as DataStreamRuntimeRequestOptions["tools"],
+        ...(unstable_assistantMessageId ? { unstable_assistantMessageId } : {}),
+        runConfig,
+        state: unstable_getMessage().metadata.unstable_state || undefined,
+        ...context.callSettings,
+        ...context.config,
+        ...this.options.body,
+      } satisfies DataStreamRuntimeRequestOptions),
+      signal: abortSignal,
+    });
+
+    await this.options.onResponse?.(result);
+
+    try {
+      if (!result.ok) {
+        throw new Error(`Status ${result.status}: ${await result.text()}`);
+      }
+      if (!result.body) {
+        throw new Error("Response body is null");
+      }
+
+      const stream = result.body
+        .pipeThrough(new DataStreamDecoder())
+        .pipeThrough(unstable_toolResultStream(context.tools, abortSignal))
+        .pipeThrough(new AssistantMessageAccumulator());
+
+      yield* asAsyncIterableStream(stream);
+
+      this.options.onFinish?.(unstable_getMessage());
+    } catch (error: unknown) {
+      this.options.onError?.(error as Error);
+      throw error;
+    }
+  }
+}
+
+export const useCustomDataStreamRuntime = (
+  options: UseDataStreamRuntimeOptions,
+): AssistantRuntime => {
+  const { localRuntimeOptions, otherOptions } =
+    splitLocalRuntimeOptions(options);
+
+  return useLocalRuntime(
+    new CustomDataStreamRuntimeAdapter(otherOptions),
+    localRuntimeOptions,
+  );
+};

--- a/src/utils/langgraph/to-assistant-ui.ts
+++ b/src/utils/langgraph/to-assistant-ui.ts
@@ -271,8 +271,6 @@ export function convertLangchainMessageContent(content: MessageContent): ThreadU
 
     // @ts-expect-error // TypeScript is not able to infer the type correctly here
     return content.map(item => {
-      console.log("Content mapping: ", item);
-
       if (typeof item === "string") {
         return {
           type: "text" as const,

--- a/src/utils/langgraph/to-assistant-ui.ts
+++ b/src/utils/langgraph/to-assistant-ui.ts
@@ -2,6 +2,8 @@
  * Conversion utilities for transforming Langgraph state messages to Assistant UI format
  */
 
+import type { CompleteAttachment } from "@assistant-ui/react";
+
 // Assistant UI Types (based on the documentation)
 export type TextMessagePart = {
   readonly type: "text";
@@ -121,7 +123,7 @@ export type ThreadSystemMessage = MessageCommonProps & {
 export type ThreadUserMessage = MessageCommonProps & {
   readonly role: "user";
   readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly unknown[];
+  readonly attachments: readonly CompleteAttachment[];
   readonly metadata: {
     readonly custom: Record<string, unknown>;
   };
@@ -330,6 +332,162 @@ export function convertLangchainMessageContent(content: MessageContent): ThreadU
   }];
 }
 
+export function extractLangchainMessageTextContent(content: MessageContent): TextMessagePart[] {
+  if (typeof content === "string") {
+    return [{
+      type: "text" as const,
+      text: content,
+    }];
+  }
+
+  if (Array.isArray(content)) {
+    const textParts: TextMessagePart[] = [];
+
+    for (const item of content) {
+      if (typeof item === "string") {
+        textParts.push({
+          type: "text" as const,
+          text: item,
+        });
+      } else if (typeof item === "object" && item.type === "text" && typeof item.text === "string") {
+        textParts.push({
+          type: "text" as const,
+          text: item.text,
+        });
+      }
+      // Skip non-text items - they will be handled as attachments
+    }
+
+    return textParts;
+  }
+
+  return [{
+    type: "text" as const,
+    text: String(content),
+  }];
+}
+
+export function extractLangchainMessageAttachments(content: MessageContent): CompleteAttachment[] {
+  const attachments: CompleteAttachment[] = [];
+
+  if (typeof content === "string") {
+    // String content has no attachments
+    return attachments;
+  }
+
+  if (Array.isArray(content)) {
+    let attachmentIndex = 0;
+
+    for (const item of content) {
+      if (typeof item === "object" && item) {
+        // Handle image_url type (from your example)
+        if (item.type === "image_url" && item.image_url && typeof item.image_url === "object" && "url" in item.image_url && typeof item.image_url.url === "string") {
+          const url = item.image_url.url;
+          const isDataUrl = url.startsWith("data:");
+          
+          // Create image content for the attachment
+          const imageContent: ThreadUserMessagePart[] = [{
+            type: "image" as const,
+            image: url,
+          }];
+
+          attachments.push({
+            id: `attachment-${attachmentIndex++}`,
+            type: "image" as const,
+            name: `image-${attachmentIndex}.png`,
+            contentType: isDataUrl ? url.split(";")[0].substring(5) : "image/png",
+            status: { type: "complete" as const },
+            content: imageContent,
+          });
+        }
+        // Handle direct image type with base64
+        else if (item.type === "image" && "source_type" in item && item.source_type === "base64" && "data" in item && typeof item.data === "string" && "mime_type" in item && typeof item.mime_type === "string") {
+          const dataUrl = `data:${item.mime_type};base64,${item.data}`;
+          
+          const imageContent: ThreadUserMessagePart[] = [{
+            type: "image" as const,
+            image: dataUrl,
+          }];
+
+          attachments.push({
+            id: `attachment-${attachmentIndex++}`,
+            type: "image" as const,
+            name: `image-${attachmentIndex}.${getFileExtensionFromMimeType(item.mime_type)}`,
+            contentType: item.mime_type,
+            status: { type: "complete" as const },
+            content: imageContent,
+          });
+        }
+        // Handle direct image type with url
+        else if (item.type === "image" && "image" in item && typeof item.image === "string") {
+          const imageUrl = item.image;
+          const isDataUrl = imageUrl.startsWith("data:");
+          
+          const imageContent: ThreadUserMessagePart[] = [{
+            type: "image" as const,
+            image: imageUrl,
+          }];
+
+          attachments.push({
+            id: `attachment-${attachmentIndex++}`,
+            type: "image" as const,
+            name: `image-${attachmentIndex}.png`,
+            contentType: isDataUrl ? imageUrl.split(";")[0].substring(5) : "image/png",
+            status: { type: "complete" as const },
+            content: imageContent,
+          });
+        }
+        // Handle file attachments (if they exist in the future)
+        else if (item.type === "file" && "data" in item && typeof item.data === "string" && "mime_type" in item && typeof item.mime_type === "string") {
+          const filename = ("filename" in item && typeof item.filename === "string") 
+            ? item.filename 
+            : `file-${attachmentIndex}.${getFileExtensionFromMimeType(item.mime_type)}`;
+
+          const fileContent: ThreadUserMessagePart[] = [{
+            type: "file" as const,
+            filename,
+            data: item.data,
+            mimeType: item.mime_type,
+          }];
+
+          attachments.push({
+            id: `attachment-${attachmentIndex++}`,
+            type: "file" as const,
+            name: filename,
+            contentType: item.mime_type,
+            status: { type: "complete" as const },
+            content: fileContent,
+          });
+        }
+      }
+    }
+  }
+
+  return attachments;
+}
+
+// Helper function to get file extension from MIME type
+function getFileExtensionFromMimeType(mimeType: string): string {
+  const mimeToExtension: Record<string, string> = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/gif": "gif",
+    "image/webp": "webp",
+    "image/svg+xml": "svg",
+    "text/plain": "txt",
+    "application/pdf": "pdf",
+    "application/json": "json",
+    "application/xml": "xml",
+    "text/html": "html",
+    "text/css": "css",
+    "text/javascript": "js",
+    "application/javascript": "js",
+  };
+
+  return mimeToExtension[mimeType] || "bin";
+}
+
 export function convertLangchainToolCalls(
   toolCalls: ToolCall[], 
   toolResults?: Map<string, { result: string; isError: boolean }>
@@ -365,14 +523,15 @@ export function convertLangchainMessageToThreadMessage(
 
   // Convert based on message type
   if (langchainMsg.id[3] === "HumanMessage") {
-    const content = convertLangchainMessageContent(langchainMsg.kwargs.content) as ThreadUserMessagePart[];
+    const textContent = extractLangchainMessageTextContent(langchainMsg.kwargs.content);
+    const attachments = extractLangchainMessageAttachments(langchainMsg.kwargs.content);
     
     return {
       id: messageId,
       role: "user" as const,
       createdAt,
-      content,
-      attachments: [],
+      content: textContent,
+      attachments,
       metadata: {
         custom: {},
       },


### PR DESCRIPTION
This pull request includes several significant updates across the backend and frontend, focusing on backend refactoring, improved message handling, and frontend component organization. The backend now uses a new directory (`mock-backend`) and replaces the previous mock server, with updates to message conversion for file and image attachments. On the frontend, markdown placeholder components have been split for better maintainability. The Makefile has also been updated to reflect these backend changes and to clean up unused targets and commands.

**Backend refactor and enhancements:**

* The backend server has been moved from `mock-server` to `mock-backend`, with all Makefile commands, clean-up routines, and setup steps updated accordingly. The backend now runs using `uvicorn` and Python, replacing the previous Node.js mock server. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-L52) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L64-R63) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L88-L94) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L103-R88) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L115-R117)
* Added `utils/message_conversion.py` to handle conversion of Assistant UI messages (including text, file, and image attachments) to the LangGraph format, and updated chat endpoints to use this conversion for better compatibility with file/image uploads. [[1]](diffhunk://#diff-05e11c0596931b0ce37322980c3d2e1e111276a8e4e0bbd14cfb47ea54ba0f81R5-R8) [[2]](diffhunk://#diff-05e11c0596931b0ce37322980c3d2e1e111276a8e4e0bbd14cfb47ea54ba0f81L29-R41) [[3]](diffhunk://#diff-05e11c0596931b0ce37322980c3d2e1e111276a8e4e0bbd14cfb47ea54ba0f81L131-R158) [[4]](diffhunk://#diff-40bf0aee04c4b4cbf80b05bd8f2ca75a8c274f2576a0249964e17ede02c18e3eR1-R94)

**Message handling improvements:**

* In `agent/graph.py`, added logic to trim messages to fit within a token limit using `trim_messages` and `count_tokens_approximately`, improving model input handling for long conversations. [[1]](diffhunk://#diff-1a333997c08909e22ad04b430e6b70a8bc714dd236c67aaf3ef50cb1a8078eb9R11-R15) [[2]](diffhunk://#diff-1a333997c08909e22ad04b430e6b70a8bc714dd236c67aaf3ef50cb1a8078eb9R55-R64)
* Improved formatting of document chunk references in Azure search tool outputs for clarity, including better labeling of file, chunk, and chunk IDs. [[1]](diffhunk://#diff-5769215a652a54dec7946507dd0e35a815aadfdccfaafa7d4dfa37ca94d32983L140-R141) [[2]](diffhunk://#diff-5769215a652a54dec7946507dd0e35a815aadfdccfaafa7d4dfa37ca94d32983L205-R206) [[3]](diffhunk://#diff-5769215a652a54dec7946507dd0e35a815aadfdccfaafa7d4dfa37ca94d32983L259-R260) [[4]](diffhunk://#diff-5769215a652a54dec7946507dd0e35a815aadfdccfaafa7d4dfa37ca94d32983L338-R339)

**Frontend component organization:**

* Split markdown placeholder components into `CustomDocReference.tsx` (for document references) and `CustomLinkReference.tsx` (for link references), improving code maintainability and clarity. [[1]](diffhunk://#diff-1a3c04ebfb3cf4d8fa9153b12faed3376374437b114ee50e18f4f38c87ebbbcdL3-R21) [[2]](diffhunk://#diff-1a3c04ebfb3cf4d8fa9153b12faed3376374437b114ee50e18f4f38c87ebbbcdL128-L161) [[3]](diffhunk://#diff-8fbb3f8dae9102d51b88e214f523eb91e80284d1cb6e7afec2500c82e5809dedR1-R52)

**Miscellaneous:**

* Updated `.gitignore` in `mock-backend` to ignore `tmp` files.